### PR TITLE
x_kernel.py: Fixed format when generating dtb's

### DIFF
--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1004,8 +1004,8 @@ class PluginImpl(PluginV2):
                     " ".join(
                         [
                             "ln -f",
-                            "${KERNEL_BUILD_ARCH_DIR}/dts/{}".format(dtb),
-                            "${SNAPCRAFT_PART_INSTALL}/dtbs/{}".format(dtb),
+                            f"${{KERNEL_BUILD_ARCH_DIR}}/dts/{dtb}",
+                            f"${{SNAPCRAFT_PART_INSTALL}}/dtbs/{dtb}",
                         ]
                     ),
                 ]


### PR DESCRIPTION
This fixes the following error generated by Snapcraft:

    Sorry, an error occurred in Snapcraft:
     'KERNEL_BUILD_ARCH_DIR'

Signed-off-by: Isaac True <isaac.true@canonical.com>