### PR TITLE
Fix errors when generating DTB files

### DIFF
--- a/x_kernel.py
+++ b/x_kernel.py
@@ -999,13 +999,20 @@ class PluginImpl(PluginV2):
             " ".join(["mkdir -p ${SNAPCRAFT_PART_INSTALL}/dtbs"]),
         ]
         for dtb in self.dtbs:
+            # Strip any subdirectories 
+            subdir_index = dtb.rfind("/")
+            if subdir_index > 0:
+                install_dtb = dtb[:subdir_index]
+            else:
+                install_dtb = dtb
+
             cmd.extend(
                 [
                     " ".join(
                         [
                             "ln -f",
                             f"${{KERNEL_BUILD_ARCH_DIR}}/dts/{dtb}",
-                            f"${{SNAPCRAFT_PART_INSTALL}}/dtbs/{dtb}",
+                            f"${{SNAPCRAFT_PART_INSTALL}}/dtbs/{install_dtb}",
                         ]
                     ),
                 ]

--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1002,7 +1002,7 @@ class PluginImpl(PluginV2):
             # Strip any subdirectories 
             subdir_index = dtb.rfind("/")
             if subdir_index > 0:
-                install_dtb = dtb[:subdir_index]
+                install_dtb = dtb[subdir_index+1:]
             else:
                 install_dtb = dtb
 

--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1004,8 +1004,8 @@ class PluginImpl(PluginV2):
                     " ".join(
                         [
                             "ln -f",
-                            "${KERNEL_BUILD_ARCH_DIR}/dts/{}".format(dtb),
-                            "${SNAPCRAFT_PART_INSTALL}/dtbs/{}".format(dtb),
+                            f"${{KERNEL_BUILD_ARCH_DIR}}/dts/{dtb}",
+                            f"${{SNAPCRAFT_PART_INSTALL}}/dtbs/{dtb}",
                         ]
                     ),
                 ]


### PR DESCRIPTION
This patchset fixes two errors when specifying the "kernel-device-trees" option in the snapcraft.yaml file. 