### PR TITLE
x_kernel.py: Fix git branch name extraction

### DIFF
--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1027,7 +1027,7 @@ class PluginImpl(PluginV2):
             " ".join(
                 [
                     "\t"
-                    "branch=$(cat ${SNAPCRAFT_PART_SRC}/debian/debian.env | awk -F '.' '{print $2}')",
+                    "branch=$(cut -d'.' -f 2- < ${SNAPCRAFT_PART_SRC}/debian/debian.env)",
                 ]
             ),
             " ".join(["\tbaseconfigdir=${SNAPCRAFT_PART_SRC}/debian.${branch}/config"]),


### PR DESCRIPTION
This fixes an issue where the git branch name is incorrectly extracted
when it contains a '.' character.

Previously, the branch 'hwe-5.13' would be extracted as 'hwe-5'. This
patch causes the full branch name to be extracted.

Signed-off-by: Isaac True <isaac.true@canonical.com>