### PR TITLE
Initial RISC-V 64-bit support

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -158,6 +158,7 @@ default_kernel_image_target = {
     "powerpc": "uImage",
     "ppc64el": "vmlinux.strip",
     "s390x": "bzImage",
+    "riscv64": "Image",
 }
 
 required_generic = [
@@ -466,7 +467,7 @@ class KernelPlugin(kbuild.KBuildPlugin):
         self.dtbs = ["{}.dtb".format(i) for i in self.options.kernel_device_trees]
         if self.dtbs:
             self.make_targets.extend(self.dtbs)
-        elif self.project.kernel_arch == "arm" or self.project.kernel_arch == "arm64":
+        elif self.project.kernel_arch == "arm" or self.project.kernel_arch == "arm64" or self.project.kernel_arch == "riscv64":
             self.make_targets.append("dtbs")
             self.make_install_targets.extend(
                 ["dtbs_install", "INSTALL_DTBS_PATH={}/dtbs".format(self.installdir)]

--- a/x_initrd.py
+++ b/x_initrd.py
@@ -123,6 +123,7 @@ default_kernel_image_target = {
     "powerpc": "uImage",
     "ppc64el": "vmlinux.strip",
     "s390x": "bzImage",
+    "riscv64": "Image",
 }
 
 # class KernelPlugin(PluginV2):
@@ -277,6 +278,8 @@ class PluginImpl(PluginV2):
             self.kernel_arch = "arm"
         elif self.target_arch == "arm64":
             self.kernel_arch = "arm64"
+        elif self.target_arch == "riscv64":
+            self.kernel_arch = "riscv64"
         elif self.target_arch == "amd64":
             self.kernel_arch = "x86"
         else:
@@ -287,6 +290,8 @@ class PluginImpl(PluginV2):
             self.deb_arch = "armhf"
         elif self.target_arch == "arm64":
             self.deb_arch = "arm64"
+        elif self.target_arch == "riscv64":
+            self.deb_arch = "riscv64"
         elif self.target_arch == "amd64":
             self.deb_arch = "amd64"
         else:

--- a/x_kernel.py
+++ b/x_kernel.py
@@ -180,6 +180,7 @@ default_kernel_image_target = {
     "powerpc": "uImage",
     "ppc64el": "vmlinux.strip",
     "s390x": "bzImage",
+    "riscv64": "Image",
 }
 
 required_generic = [
@@ -449,6 +450,8 @@ class PluginImpl(PluginV2):
             self.kernel_arch = "arm"
         elif self.target_arch == "arm64":
             self.kernel_arch = "arm64"
+        elif self.target_arch == "riscv64":
+            self.kernel_arch = "riscv"
         elif self.target_arch == "amd64":
             self.kernel_arch = "x86"
         else:
@@ -459,6 +462,8 @@ class PluginImpl(PluginV2):
             self.deb_arch = "armhf"
         elif self.target_arch == "arm64":
             self.deb_arch = "arm64"
+        elif self.target_arch == "riscv64":
+            self.deb_arch = "riscv64"
         elif self.target_arch == "amd64":
             self.deb_arch = "amd64"
         else:
@@ -488,7 +493,7 @@ class PluginImpl(PluginV2):
         self.dtbs = ["{}.dtb".format(i) for i in self.options.kernel_device_trees]
         if self.dtbs:
             self.make_targets.extend(self.dtbs)
-        elif self.kernel_arch == "arm" or self.kernel_arch == "arm64":
+        elif self.kernel_arch == "arm" or self.kernel_arch == "arm64" or self.kernel_arch == "riscv64":
             self.make_targets.append("dtbs")
             self.make_install_targets.extend(
                 ["dtbs_install", "INSTALL_DTBS_PATH=${SNAPCRAFT_PART_INSTALL}/dtbs"]


### PR DESCRIPTION
This commit adds support for RISC-V 64-bit. 

I can extend this to 32-bit as well if you'd like.

The only thing missing is supported initrd downloads for RISC-V. In order to build the initramfs, building a riscv `ubuntu-core-initramfs` is needed. The only real blocker package-wise on this from what I can tell is a lack of support for RISC-V from `systemd-bootchart` (it seems to be the only dependency not built for RISC-V) -- the project seems to have lost a lot of momentum, but the patch I have to add RISC-V support seems to be sufficient. I don't intend on sending any of my work to the relevant maintainers until RISC-V is an officially supported project for Ubuntu Core, and we can hold off on this PR if you think it's wise to wait.
I am more than happy to build the initrds as needed and send them to you if you'd like. Otherwise I have a deb you can use yourself [here](https://github.com/dilyn-corner/ubuntu-core-riscv64/blob/main/riscv64-components/ubuntu-core-initramfs_51_riscv64.deb).

Signed-off-by: Dilyn Corner <dilyn.corner@tutanota.com>