### PR TITLE
x_kernel.py: Add missing import for the re module

### DIFF
--- a/x_kernel.py
+++ b/x_kernel.py
@@ -159,6 +159,7 @@ import click
 import logging
 import os
 import sys
+import re
 
 from snapcraft import ProjectOptions
 from typing import Any, Dict, List, Set


### PR DESCRIPTION
The following line uses the re module:

    makeflags = re.sub(r"-I[\S]*", "", os.environ["MAKEFLAGS"])

This patch adds the necessary import for this to work. Otherwise, the following error is generated: 

    Sorry, an error occurred in Snapcraft:
    name 're' is not defined