### PR TITLE
x_kernel: remove old reference to file_utils

### DIFF
--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1097,8 +1097,6 @@ class PluginImpl(PluginV2):
         # elif kconfigflavour is provided, assemble the ubuntu.flavour config
         # otherwise use defconfig to seed the base config
         if self.options.kconfigfile:
-            # This file gets modified, no hard links here
-            file_utils.copy(self.options.kconfigfile, config_path)
             cmd.extend(
                 [
                     " ".join(


### PR DESCRIPTION
This line has been replaced by a shell command on the next line.

Signed-off-by: Isaac True <isaac.true@canonical.com>