### PR TITLE
x_kernel: fix AptGPGKeyInstallError invocation

### DIFF
--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1361,6 +1361,7 @@ class PluginImpl(PluginV2):
                 try:
                     subprocess.run(
                         [
+                            "sudo",
                             "apt-key",
                             "adv",
                             "--keyserver",

--- a/x_kernel.py
+++ b/x_kernel.py
@@ -1374,7 +1374,7 @@ class PluginImpl(PluginV2):
                     )
                 except subprocess.CalledProcessError as error:
                     raise errors.AptGPGKeyInstallError(
-                        error.output.decode(), key=_SNAPPY_DEV_KEY_FINGERPRINT
+                        output=error.output.decode(), key=_SNAPPY_DEV_KEY_FINGERPRINT
                     )
 
             # add ppa itself


### PR DESCRIPTION
This resolves the following error when an Apt key fails to be installed on the system:

    TypeError: __init__() takes 1 positional argument but 2 positional arguments (and 1 keyword-only argument) were given

Signed-off-by: Isaac True <isaac.true@canonical.com>